### PR TITLE
Add formula for Helm 3.11.1

### DIFF
--- a/Formula/helm@3.11.1.rb
+++ b/Formula/helm@3.11.1.rb
@@ -1,0 +1,39 @@
+class HelmAT3111 < Formula
+  desc "Kubernetes package manager"
+  homepage "https://helm.sh/"
+  url "https://github.com/helm/helm.git",
+      tag:      "v3.11.1",
+      revision: "293b50c65d4d56187cd4e2f390f0ada46b4c4737"
+  license "Apache-2.0"
+  head "https://github.com/helm/helm.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    # Don't dirty the git tree
+    rm_rf ".brew_home"
+
+    system "make", "build"
+    bin.install "bin/helm"
+
+    mkdir "man1" do
+      system bin/"helm", "docs", "--type", "man"
+      man1.install Dir["*"]
+    end
+
+    generate_completions_from_executable(bin/"helm", "completion")
+  end
+
+  test do
+    system bin/"helm", "create", "foo"
+    assert File.directory? testpath/"foo/charts"
+
+    version_output = shell_output(bin/"helm version 2>&1")
+    assert_match "GitTreeState:\"clean\"", version_output
+    if build.stable?
+      revision = stable.specs[:revision]
+      assert_match "GitCommit:\"#{revision}\"", version_output
+      assert_match "Version:\"v#{version}\"", version_output
+    end
+  end
+end


### PR DESCRIPTION
## Why
* It's the current version used by Fedora folks (as per ansible scripts in bootstrap repo)
* Gets rid this pesky error log: `ERRO[0000] failure getting variant error="getCPUInfo for OS darwin: not implemented"`
* Fixes broken auto-complete in fish shell