### PR TITLE
Add kubectl / kubernetes CLI 1.27 

### DIFF
--- a/Formula/kubernetes-cli@1.27.rb
+++ b/Formula/kubernetes-cli@1.27.rb
@@ -1,0 +1,48 @@
+class KubernetesCliAT127 < Formula
+  desc "Kubernetes command-line interface"
+  homepage "https://kubernetes.io/"
+  url "https://github.com/kubernetes/kubernetes.git",
+      tag:      "v1.27.4",
+      revision: "fa3d7990104d7c1f16943a67f11b154b71f6a132"
+  license "Apache-2.0"
+  head "https://github.com/kubernetes/kubernetes.git", branch: "master"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "bash" => :build
+  depends_on "coreutils" => :build
+  depends_on "go" => :build
+
+  uses_from_macos "rsync" => :build
+
+  def install
+    # Don't dirty the git tree
+    rm_rf ".brew_home"
+
+    ENV.prepend_path "PATH", Formula["coreutils"].libexec/"gnubin" # needs GNU date
+    system "make", "WHAT=cmd/kubectl"
+    bin.install "_output/bin/kubectl"
+
+    generate_completions_from_executable(bin/"kubectl", "completion", base_name: "kubectl")
+
+    # Install man pages
+    # Leave this step for the end as this dirties the git tree
+    system "hack/update-generated-docs.sh"
+    man1.install Dir["docs/man/man1/*.1"]
+  end
+
+  test do
+    run_output = shell_output("#{bin}/kubectl 2>&1")
+    assert_match "kubectl controls the Kubernetes cluster manager.", run_output
+
+    version_output = shell_output("#{bin}/kubectl version --client 2>&1")
+    assert_match "GitTreeState:\"clean\"", version_output
+    if build.stable?
+      revision = stable.specs[:revision]
+      assert_match revision.to_s, version_output
+    end
+  end
+end


### PR DESCRIPTION
this version is compatible w. our current server version (Server Version: v1.28.7-eks-b9c9ed7) . pinning it because the homebrew core repo is at like 1.30

we had an issue here: https://github.com/codecademy-engineering/bootstrap/pull/101 of an install failing during

```
brew extract --verbose --version=1.27 kubernetes-cli codecademy-engineering/bootstrap
```

because the users local tap didn't include the `core` tap (not sure why), which is where `1.27` is located. so instead of attempting to extract an older version from core, i'm pinning this formula directly to our private tap so we can install it from here (since we always include our own tap in brew as part of bootstrapping steps)