### PR TITLE
pin helm 3.14.4 and helmfile 0.144.0

### DIFF
--- a/Formula/helm@3.14.4.rb
+++ b/Formula/helm@3.14.4.rb
@@ -1,0 +1,36 @@
+class HelmAT3144 < Formula
+  desc "Kubernetes package manager"
+  homepage "https://helm.sh/"
+  url "https://github.com/helm/helm.git",
+      tag:      "v3.14.4",
+      revision: "81c902a123462fd4052bc5e9aa9c513c4c8fc142"
+  license "Apache-2.0"
+  head "https://github.com/helm/helm.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    system "make", "build"
+    bin.install "bin/helm"
+
+    mkdir "man1" do
+      system bin/"helm", "docs", "--type", "man"
+      man1.install Dir["*"]
+    end
+
+    generate_completions_from_executable(bin/"helm", "completion")
+  end
+
+  test do
+    system bin/"helm", "create", "foo"
+    assert File.directory? testpath/"foo/charts"
+
+    version_output = shell_output(bin/"helm version 2>&1")
+    assert_match "GitTreeState:\"clean\"", version_output
+    if build.stable?
+      revision = stable.specs[:revision]
+      assert_match "GitCommit:\"#{revision}\"", version_output
+      assert_match "Version:\"v#{version}\"", version_output
+    end
+  end
+end

--- a/Formula/helmfile@0.144.0.rb
+++ b/Formula/helmfile@0.144.0.rb
@@ -1,0 +1,36 @@
+class HelmfileAT01440 < Formula
+  desc "Deploy Kubernetes Helm Charts"
+  homepage "https://github.com/roboll/helmfile"
+  url "https://github.com/roboll/helmfile/archive/v0.144.0.tar.gz"
+  sha256 "fc767d10ec21ca464caaefd309f410d96685a985090c237907a22bd983112c62"
+  license "MIT"
+
+  depends_on "go" => :build
+  depends_on "helm"
+
+  def install
+    system "go", "build", "-ldflags", "-X github.com/roboll/helmfile/pkg/app/version.Version=v#{version}",
+             "-o", bin/"helmfile", "-v", "github.com/roboll/helmfile"
+  end
+
+  test do
+    (testpath/"helmfile.yaml").write <<-EOS
+    repositories:
+    - name: stable
+      url: https://charts.helm.sh/stable
+
+    releases:
+    - name: vault                            # name of this release
+      namespace: vault                       # target namespace
+      createNamespace: true                  # helm 3.2+ automatically create release namespace (default true)
+      labels:                                # Arbitrary key value pairs for filtering releases
+        foo: bar
+      chart: stable/vault                    # the chart being installed to create this release, referenced by `repository/chart` syntax
+      version: ~1.24.1                       # the semver of the chart. range constraint is supported
+    EOS
+    system Formula["helm"].opt_bin/"helm", "create", "foo"
+    output = "Adding repo stable https://charts.helm.sh/stable"
+    assert_match output, shell_output("#{bin}/helmfile -f helmfile.yaml repos 2>&1")
+    assert_match version.to_s, shell_output("#{bin}/helmfile -v")
+  end
+end


### PR DESCRIPTION
based on investigation by @mbacchi 

helm version rationale

slack convo: https://codecademy.slack.com/archives/C6F20UBP0/p1715698659535439?thread_ts=1715698640.842579&cid=C6F20UBP0

> **Matthew Bacchi**: Helm and helmfile (similar to kubectl) should be updated in step with our k8s cluster versionss. We're on [EKS 1.28 now](https://github.com/codecademy-engineering/infrastructure/blob/main/terraform/projects/codecademy/production/aws/eks_blue/main.tf#L9), which according to [this table](https://helm.sh/docs/topics/version_skew/#supported-version-skew) indicates we should upgrade to helm 3.13.x or 3.14.x.

helmfile version rationale

keep consistent with current version in GHA
https://github.com/codecademy-engineering/github-actions/blob/v1.4.1/.github/actions/deploy/action.yaml#L55-L64